### PR TITLE
Show mute buttons on gain-change

### DIFF
--- a/VoicemeeterOsdProgram/Factories/OsdContentFactory.Parameters.cs
+++ b/VoicemeeterOsdProgram/Factories/OsdContentFactory.Parameters.cs
@@ -28,7 +28,7 @@ namespace VoicemeeterOsdProgram.Factories
         private static void MakeFaderParam(StripControl strip, int i, StripType type)
         {
             var p = new VoicemeeterNumParam(VoicemeeterApiClient.Api, Gain(i, type));
-            strip.FaderCont.VmParameter = p;
+            strip.VmFaderParameter = p;
             m_vmParams.Add(p);
         }
 

--- a/VoicemeeterOsdProgram/Factories/OsdContentFactory.cs
+++ b/VoicemeeterOsdProgram/Factories/OsdContentFactory.cs
@@ -98,7 +98,7 @@ namespace VoicemeeterOsdProgram.Factories
 
             btn = StripButtonFactory.GetMute();
             MakeButtonParam(BtnType.Mute, StripType.Output, btn, stripIndex);
-            strip.ControlBtnsContainer.Children.Add(btn);
+            strip.AdditionalControlBtns.Children.Add(btn);
 
             switch (m_vmProperties.type)
             {
@@ -123,7 +123,7 @@ namespace VoicemeeterOsdProgram.Factories
 
             btn = StripButtonFactory.GetMute();
             MakeButtonParam(BtnType.Mute, StripType.Input, btn, stripIndex);
-            strip.ControlBtnsContainer.Children.Add(btn);
+            strip.AdditionalControlBtns.Children.Add(btn);
 
             // adding A1, A2, ... buttons
             for (int i = 0; i < m_vmProperties.hardOutputs; i++)

--- a/VoicemeeterOsdProgram/Factories/OsdContentFactory.cs
+++ b/VoicemeeterOsdProgram/Factories/OsdContentFactory.cs
@@ -99,7 +99,7 @@ namespace VoicemeeterOsdProgram.Factories
             btn = StripButtonFactory.GetMute();
             strip.MuteButton = btn;
             MakeButtonParam(BtnType.Mute, StripType.Output, btn, stripIndex);
-            strip.AdditionalControlBtns.Children.Add(btn);
+            strip.ControlBtnsContainer.Children.Add(btn);
 
             switch (m_vmProperties.type)
             {
@@ -125,7 +125,7 @@ namespace VoicemeeterOsdProgram.Factories
             btn = StripButtonFactory.GetMute();
             strip.MuteButton = btn;
             MakeButtonParam(BtnType.Mute, StripType.Input, btn, stripIndex);
-            strip.AdditionalControlBtns.Children.Add(btn);
+            strip.ControlBtnsContainer.Children.Add(btn);
 
             // adding A1, A2, ... buttons
             for (int i = 0; i < m_vmProperties.hardOutputs; i++)

--- a/VoicemeeterOsdProgram/Factories/OsdContentFactory.cs
+++ b/VoicemeeterOsdProgram/Factories/OsdContentFactory.cs
@@ -97,6 +97,7 @@ namespace VoicemeeterOsdProgram.Factories
             strip.ControlBtnsContainer.Children.Add(btn);
 
             btn = StripButtonFactory.GetMute();
+            strip.MuteButton = btn;
             MakeButtonParam(BtnType.Mute, StripType.Output, btn, stripIndex);
             strip.AdditionalControlBtns.Children.Add(btn);
 
@@ -122,6 +123,7 @@ namespace VoicemeeterOsdProgram.Factories
             strip.ControlBtnsContainer.Children.Add(btn);
 
             btn = StripButtonFactory.GetMute();
+            strip.MuteButton = btn;
             MakeButtonParam(BtnType.Mute, StripType.Input, btn, stripIndex);
             strip.AdditionalControlBtns.Children.Add(btn);
 

--- a/VoicemeeterOsdProgram/UiControls/OSD/Strip/StripControl.Voicemeeter.cs
+++ b/VoicemeeterOsdProgram/UiControls/OSD/Strip/StripControl.Voicemeeter.cs
@@ -8,6 +8,8 @@ namespace VoicemeeterOsdProgram.UiControls.OSD.Strip
 
         private VoicemeeterStrParam m_vmParam;
 
+        public ButtonContainer MuteButton { get; set; }
+
         public VoicemeeterStrParam VmParameter
         {
             get => m_vmParam;
@@ -29,6 +31,26 @@ namespace VoicemeeterOsdProgram.UiControls.OSD.Strip
             }
         }
 
+        public VoicemeeterNumParam VmFaderParameter
+        {
+            get => FaderCont.VmParameter;
+            set
+            {
+                if (value is null)
+                {
+                    if (FaderCont.VmParameter is not null)
+                    {
+                        FaderCont.VmParameter.ReadValueChanged -= OnVmGainChanged;
+                        FaderCont.VmParameter = null;
+                    }
+                    return;
+                }
+
+                FaderCont.VmParameter = value;
+                FaderCont.VmParameter.ReadValueChanged += OnVmGainChanged;
+            }
+        }
+
         private void OnVmValueRead(object sender, ValOldNew<string> e)
         {
             string name = e.newVal;
@@ -36,6 +58,14 @@ namespace VoicemeeterOsdProgram.UiControls.OSD.Strip
             if (StripLabel.Text == newName) return;
 
             StripLabel.Text = newName;
+        }
+
+        private void OnVmGainChanged(object sender, ValOldNew<float> e)
+        {
+            if (MuteButton != null)
+            {
+                MuteButton.Visibility = System.Windows.Visibility.Visible;
+            }
         }
     }
 }

--- a/VoicemeeterOsdProgram/UiControls/OSD/Strip/StripControl.xaml
+++ b/VoicemeeterOsdProgram/UiControls/OSD/Strip/StripControl.xaml
@@ -27,15 +27,14 @@
                 <ColumnDefinition/>
                 <ColumnDefinition/>
             </Grid.ColumnDefinitions>
-            <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                <Grid.RowDefinitions>
-                    <RowDefinition/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-                <local:FaderContainer x:Name="FaderCont"/>
-                <StackPanel Name="AdditionalControlBtns" Grid.Row="1"/>
-            </Grid>
-            <Grid Grid.Column="1"
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition/>
+            </Grid.RowDefinitions>
+
+            <StackPanel Name="AdditionalControlBtns" Grid.Row="0" Grid.ColumnSpan="2"/>
+            <local:FaderContainer x:Name="FaderCont" Grid.Column="0" Grid.Row="1"/>
+            <Grid Grid.Column="1" Grid.Row="1"
                         HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                 <Grid.RowDefinitions>
                     <RowDefinition/>

--- a/VoicemeeterOsdProgram/UiControls/OSD/Strip/StripControl.xaml
+++ b/VoicemeeterOsdProgram/UiControls/OSD/Strip/StripControl.xaml
@@ -27,14 +27,15 @@
                 <ColumnDefinition/>
                 <ColumnDefinition/>
             </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition/>
-            </Grid.RowDefinitions>
-
-            <StackPanel Name="AdditionalControlBtns" Grid.Row="0" Grid.ColumnSpan="2"/>
-            <local:FaderContainer x:Name="FaderCont" Grid.Column="0" Grid.Row="1"/>
-            <Grid Grid.Column="1" Grid.Row="1"
+            <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                <Grid.RowDefinitions>
+                    <RowDefinition/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <local:FaderContainer x:Name="FaderCont"/>
+                <StackPanel Name="AdditionalControlBtns" Grid.Row="1"/>
+            </Grid>
+            <Grid Grid.Column="1"
                         HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                 <Grid.RowDefinitions>
                     <RowDefinition/>


### PR DESCRIPTION
I personally use FancyOSD as a volume-slider for Voicemeeter. It can be confusing to show volume adjustments on a muted bus without showing the mute button, as the current fader style can give the impression that the bus is not muted.

This pull changes the mute button visibility conditions so that changes in gain will trigger the mute button to display as well. 

Here is the resulting appearance:
![image](https://user-images.githubusercontent.com/6509035/157856307-9ac629ba-ef8e-4bcf-b8d6-308db139d459.png)